### PR TITLE
Revert "Bump h5py from 3.12.1 to 3.13.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ flatbuffers==25.2.10
 gast==0.6.0
 google-pasta==0.2.0
 grpcio==1.70.0
-h5py==3.13.0
+h5py==3.12.1
 idna==3.10
 keras==3.8.0
 libclang==18.1.1


### PR DESCRIPTION
Reverts harsha7addanki/Eye-Tracking-Mouse-Cursor#7

The user requested numpy==2.2.3
    h5py 3.13.0 depends on numpy>=1.19.3
    keras 3.8.0 depends on numpy
    ml-dtypes 0.5.1 depends on numpy>=1.21
    ml-dtypes 0.5.1 depends on numpy>=1.21.2; python_version >= "3.10"
    opencv-python 4.11.0.86 depends on numpy>=1.17.0; python_version >= "3.7"    
    opencv-python 4.11.0.86 depends on numpy>=1.21.2; python_version >= "3.10"   
    opencv-python 4.11.0.86 depends on numpy>=1.17.3; python_version >= "3.8"    
    opencv-python 4.11.0.86 depends on numpy>=1.19.3; python_version >= "3.9"    
    pandas 2.2.3 depends on numpy>=1.22.4; python_version < "3.11"
    tensorboard 2.19.0 depends on numpy>=1.12.0
    tensorflow-intel 2.18.0 depends on numpy<2.1.0 and >=1.26.0

at the root h5py is the problem