### PR TITLE
Revert "Bump ml-dtypes from 0.4.1 to 0.5.1"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ Markdown==3.7
 markdown-it-py==3.0.0
 MarkupSafe==3.0.2
 mdurl==0.1.2
-ml-dtypes==0.5.1
+ml-dtypes==0.4.1
 namex==0.0.8
 numpy==2.2.3
 opencv-python==4.11.0.86


### PR DESCRIPTION
Reverts harsha7addanki/Eye-Tracking-Mouse-Cursor#6
causes issues with current tensorflow version